### PR TITLE
ENG-46755 Send start and finish time to Datadog.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,11 +28,14 @@
       - changed:{{ resources_changed | string | lower }}
       - cluster:{{ kube_cluster_name }}
       - config:{{ config_version }}
+      - duration:{{ (end_time|int - start_time|int) * 1000000000 }}
       - env:{{ env }}
       - environment:{{ env }}
+      - finished:{{ (end_time|int) * 1000 }}
       - instance:{{ instance }}
       - namespace:{{ kube_resource_namespace }}
       - service:{{ application }}
+      - started:{{ start_time|int * 1000 }}
       - success:{{ deploy_success | string | lower }}
       - type:deployment
       - version:{{ version }}


### PR DESCRIPTION
This comes out of me trying to clearly prove I actually did something useful in allowing kafka-connect burst higher in regards to ES deployments. Trying to improve deployment performance metrics visibility in Datadog.

I know the grafana callback reports the values of `deployment_start_time` and `deployment_end_time`, however:
1. I don't know where these values actually go in grafana, and
2. These timestamps are defined in the applications/generics tasks, so they only report the duration of the latest deployment manifest update, and I don't believe would included db_init jobs or give good metrics on deployment playbook runs with mutliple deployment manifests (i.e. ES).

I would like to continue to improve this and maybe add events for tracking timings of subcomponents of the deployment (db_init, multi-service deployments), but like this as a starting point.

Example events in [Datadog](https://app.datadoghq.com/event/explorer?query=source%3Aansible%20service%3Aadmin-api%20&agg_m=%40duration&agg_m_source=base&agg_t=avg&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cols=%40duration&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&view=spans&viz=timeseries&from_ts=1712897884338&to_ts=1712901484338&live=false)

Updated the Ansible Deployments Events [DataDog event pipeline](https://app.datadoghq.com/event/pipelines) to process these tags into event attributes.